### PR TITLE
API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Slider(
 `Slider` supports 2 different modes of tracking. Specify it when initializing: 
 
 ```Swift
-Slider(options: [.tracks( /* .onMovement, .onLocation or .onLocationOnceMoved */ )])
+Slider(options: [.tracks( /* .onTranslation, .onLocation or .onLocationOnceMoved */ )])
 ```
 
 - The default tracking behavior is `.onTranslation`. In this mode, the slider cares about the finger's movements and distances, instead of its position. It's the same as Safari video player progress bar in iOS 16.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ https://user-images.githubusercontent.com/12840982/194141815-8c48bb74-e792-4d92-
 
 Use Swift Package Manager to add it to your project. On how to use Swift Package Manager, read this: https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app
 
-`import Slyderin` into your source file, and add a `Slyder` object to your view:
+`import Slyderin` into your source file, and add a `Slider` object to your view:
 
 ```Swift
 import Slyderin
 class ViewController: UIViewController {   
-    private weak var slider: Slyder!
+    private weak var slider: Slider!
 	// ......
     func loadView() {
         super.loadView()
-        let slider = Slyder()
+        let slider = Slider()
         view.addSubview(slider)
         // your layout code......
     }
@@ -29,11 +29,11 @@ class ViewController: UIViewController {
 
 ### About Layout
 
-**The size of the `Slyder` is not intrinsic**, meaning it won't have a size of its own. You have to prevent its size or position from being ambiguous. For example, if you set a bottom constraint for it, you then have to set a top constraint or a height constraint for it, too. 
+**The size of the `Slider` is not intrinsic**, meaning it won't have a size of its own. You have to prevent its size or position from being ambiguous. For example, if you set a bottom constraint for it, you then have to set a top constraint or a height constraint for it, too. 
 
 
 
-**A `Slyder` has a built-in padding of 20px on each side by default, to increase the touch area.** This causes the slider to be indented. For example, if you want a slider to fit in some view with a 20px padding on each side:
+**A `Slider` has a built-in padding of 20px on each side by default, to increase the touch area.** This causes the slider to be indented. For example, if you want a slider to fit in some view with a 20px padding on each side:
 
 ```swift
 slider.fillSuperview(padding: 20)
@@ -54,7 +54,7 @@ However, if you do want to change the paddings, they are in its `directionalLayo
 Set the slider's `valueChangeHandler` or call `onValueChange(_:)` to receive value changes:
 
 ```Swift
-Slyder()
+Slider()
     .height(50)
     .onValueChange {
 		// new value $0 received
@@ -70,10 +70,10 @@ Slyder()
 Slyderin uses `Slyderin.ThumblessSlider` by default. You can change its initializer's parameters to more-or-less do some customizations:
 
 ```Swift
-Slyder(
+Slider(
     slider: ThumblessSlider(
         direction: .bottomToTop,
-        scaleRatio: ThumblessSlider.ScaleRatio(ratioOnAxis: 1.05, ratioAgainstAxis: 1.15),
+        scaling: .both(onAxis: 1.05, againstAxis: 1.15),
         cornerRadius: .fixed(12),
         visualEffect: UIBlurEffect(style: .systemMaterialDark)
     )
@@ -85,11 +85,7 @@ Slyder(
     - `leadingToTrailing`. The slider is horizontal and the track is filled from the leading side to the trailing side when the user slides in leading-to-trailing direction. This is the default direction.
     - `bottomToTop`. The slider is vertical and the track is filled from bottom to top when the user slides upwards.
 
-- `scaleRatio`. The slider expands its size when responding to user inputs. This parameter specifies the expanding ratio. 
-
-    - If you set it to `ScaleRatio(ratioOnAxis: 1.05, ratioAgainstAxis: 1.15)`, for a horizontal slider, its 1.05 times wider and 1.15 times higher. Defaults to (1, 1).
-
-    - > Versions <= 0.0.2 has a default scale ratio of `ScaleRatio(ratioOnAxis: 1.05, ratioAgainstAxis: 2)`.
+- `scaling`. The slider expands its size when responding to user inputs. This parameter specifies the expanding ratio. If you set it to `.both(onAxis: 1.05, againstAxis: 1.15)`, for a horizontal slider, its becomes 1.05 times wider and 1.15 times taller. Defaults to (1, 1).
 
 - `cornerRadius` provides 2 different modes of corner radius:
 
@@ -104,24 +100,21 @@ Slyder(
 
 ### About Tracking Modes
 
-`Slyder` supports 2 different modes of tracking. Specify it when initializing: 
+`Slider` supports 2 different modes of tracking. Specify it when initializing: 
 
 ```Swift
-Slyder(options: [.trackingBehavior( /* .trackMovement or .trackTouch() */ )])
+Slider(options: [.tracks( /* .onMovement, .onLocation or .onLocationOnceMoved */ )])
 ```
 
-- The default tracking behavior is `.trackMovement`. In this mode, the slider cares about the finger's movements and distances, instead of its position. It's the same as Safari video player progress bar in iOS 16.
-- The other mode is `.trackTouch(respondsImmediately: Bool)`. In this mode, the thumb (the filled track) moves to where the finger is. 
-    - If `respondsImmediately` is `true`, the value changes immediately when the user put the finger onto the slider. Otherwise the value won't change until the user moves the finger.
-
-
+- The default tracking behavior is `.onTranslation`. In this mode, the slider cares about the finger's movements and distances, instead of its position. It's the same as Safari video player progress bar in iOS 16.
+- The other modes (`.onLocation` / `.onLocationOnceMoved`), the thumb (the filled track) moves to where the finger is. Specifically, under `.onLocationOnceMoved` mode, the slider won't start tracking until the finger moves.
 
 
 ---
 
-## Make Your Own Slyder
+## Make Your Own Slider
 
-You can specify a slider when initializing `Slyder`, as long as it is `Slidable`:
+You can specify a slider when initializing `Slider`, as long as it is `Slidable`:
 
 ```Swift
 init(slider: Slidable = DefaultSlider(), options: [Option] = [])
@@ -131,11 +124,11 @@ init(slider: Slidable = DefaultSlider(), options: [Option] = [])
 
 ### UIKit values
 
-`Slyder` respects some of the standard UIKit parameters:
+`Slider` respects some of the standard UIKit parameters:
 
 - `tintColor` changes the color of the filled track. Inherited from the superview by default.
 - `directionalLayoutMargins` determines the slider's margins from its touch-responsive area. Defaults to 20px each side.
-- `semanticContentAttribute` determines whether the slider should flip when the interface layout direction is right-to-left. Defaults to `unspecifed`, which means it flips. Changes to this value won't apply until the next time the `Slyder` is added to superview.
+- `semanticContentAttribute` determines whether the slider should flip when the interface layout direction is right-to-left. Defaults to `unspecifed`, which means it flips. Changes to this value won't apply until the next time the `Slider` is added to superview.
 - `overrideUserInterfaceStyle` determines the blur effect is light or dark, if you have not specify a light or dark one.
 
 
@@ -145,7 +138,7 @@ init(slider: Slidable = DefaultSlider(), options: [Option] = [])
 There is also a built-in `UISlider` subclass: `Slyderin.UIKitSlider`, which, unfortunately, supports only the leading-to-trailing direction:
 
 ```Swift
-Slyder(slider: UIKitSlider())
+Slider(slider: UIKitSlider())
 ```
 
 https://user-images.githubusercontent.com/12840982/194141894-fc9b7596-9be8-4247-bc0c-d422760a7591.mov
@@ -157,10 +150,10 @@ You can implement your own `Slidable`:
 ```Swift
 public protocol Slidable: AnyObject where Self: UIView {
     var direction: Direction { get }
-    func fit(_ viewModel: Slyder.ViewModel)
+    func fit(_ viewModel: Slider.ViewModel)
 }
 
-extension Slyder {
+extension Slider {
     public struct ViewModel {
         public var maximumValue: Double = 1
         public var minimumValue: Double = 0

--- a/Sources/Slyderin/Slidable.swift
+++ b/Sources/Slyderin/Slidable.swift
@@ -10,10 +10,10 @@ import UIKit
 public protocol Slidable: AnyObject where Self: UIView {
     var direction: Direction { get }
     
-    func fit(_ viewModel: Slyder.ViewModel)
+    func fit(_ viewModel: Slider.ViewModel)
 }
 
-extension Slidable {
+public extension Slidable {
     var layoutDirection: UIUserInterfaceLayoutDirection {
         UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
     }
@@ -125,7 +125,7 @@ public enum Direction {
         }
     }
     
-    enum Axis {
+    public enum Axis {
         case xAxis
         case yAxis
         

--- a/Sources/Slyderin/Slider+Options.swift
+++ b/Sources/Slyderin/Slider+Options.swift
@@ -9,7 +9,9 @@ import Foundation
 
 public extension Slider {
     enum Option {
+        @available(*, deprecated, renamed: "tracks", message: "")
         case trackingBehavior(TrackingBehavior = .trackMovement)
+        case tracks(TrackingBehavior = .trackMovement)
     }
     
     struct Options {
@@ -27,10 +29,17 @@ public extension Slider {
     }
     
     enum TrackingBehavior {
-        /// The thumb of the slider is attached to the user's finger.
+        @available(*, deprecated, renamed: "onLocationOnceMoved", message: "Use onMovingLocation if respondsImmediately is false, otherwise use onLocation.")
         case trackTouch(respondsImmediately: Bool)
-        /// The thumb of the slider moves the same distance on the same direction with the user's finger.
+        @available(*, deprecated, renamed: "onMovement", message: "")
         case trackMovement
+        
+        /// The thumb of the slider is always attached to the user's finger.
+        case onLocation
+        /// The thumb of the slider follows the finger once it starts moving.
+        case onLocationOnceMoved
+        /// The thumb of the slider moves the same distance on the same direction with the user's finger.
+        case onTranslation
     }
 }
 
@@ -39,7 +48,7 @@ extension Array where Element == Slider.Option {
         var options = Slider.Options()
         for option in self {
             switch option {
-            case .trackingBehavior(let behavior):
+            case .trackingBehavior(let behavior), .tracks(let behavior):
                 options.trackingBehavior = behavior
             }
         }

--- a/Sources/Slyderin/Slider+Options.swift
+++ b/Sources/Slyderin/Slider+Options.swift
@@ -11,7 +11,7 @@ public extension Slider {
     enum Option {
         @available(*, deprecated, renamed: "tracks", message: "")
         case trackingBehavior(TrackingBehavior = .trackMovement)
-        case tracks(TrackingBehavior = .trackMovement)
+        case tracks(TrackingBehavior = .onTranslation)
     }
     
     struct Options {
@@ -22,7 +22,7 @@ public extension Slider {
         public var trackingBehavior: TrackingBehavior
         
         public init(
-            trackingBehavior: TrackingBehavior = .trackMovement
+            trackingBehavior: TrackingBehavior = .onTranslation
         ) {
             self.trackingBehavior = trackingBehavior
         }

--- a/Sources/Slyderin/Slider+Options.swift
+++ b/Sources/Slyderin/Slider+Options.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public extension Slyder {
+public extension Slider {
     enum Option {
         case trackingBehavior(TrackingBehavior = .trackMovement)
     }
@@ -34,9 +34,9 @@ public extension Slyder {
     }
 }
 
-extension Array where Element == Slyder.Option {
-    var asOptions: Slyder.Options {
-        var options = Slyder.Options()
+extension Array where Element == Slider.Option {
+    var asOptions: Slider.Options {
+        var options = Slider.Options()
         for option in self {
             switch option {
             case .trackingBehavior(let behavior):

--- a/Sources/Slyderin/Slider+ViewModel.swift
+++ b/Sources/Slyderin/Slider+ViewModel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-extension Slyder {
+extension Slider {
     public struct ViewModel {
         public var maximumValue: Double = 1
         public var minimumValue: Double = 0

--- a/Sources/Slyderin/Slider.swift
+++ b/Sources/Slyderin/Slider.swift
@@ -1,6 +1,10 @@
 import UIKit
 
-open class Slyder: UIView {
+
+@available(*, deprecated, renamed: "Slider", message: "Use Slider or Slyderin.Slider instead.")
+public typealias Slyder = Slider
+
+open class Slider: UIView {
     open internal(set) var slider: Slidable
     open internal(set) var options: Options
     
@@ -125,7 +129,7 @@ open class Slyder: UIView {
 
 
 // MARK: tracking
-private extension Slyder {
+private extension Slider {
     func handleTouchDown(on point: CGPoint) {
         switch options.trackingBehavior {
         case .trackMovement:
@@ -178,7 +182,7 @@ private extension Slyder {
 
 
 // MARK: build view
-private extension Slyder {
+private extension Slider {
     func fit(_ viewModel: ViewModel) {
         slider.fit(viewModel)
     }

--- a/Sources/Slyderin/Slider.swift
+++ b/Sources/Slyderin/Slider.swift
@@ -99,7 +99,7 @@ open class Slider: UIView {
         }
         let location = touch.location(in: self)
         switch options.trackingBehavior {
-        case .trackMovement:
+        case .trackMovement, .onTranslation:
             let translation = CGVector(
                 dx: location.x - touchPointWhenBagan.x,
                 dy: location.y - touchPointWhenBagan.y
@@ -107,7 +107,7 @@ open class Slider: UIView {
             viewModel = updateViewModel(
                 viewModel, by: translation, from: valueWhenTouchBegan
             )
-        case .trackTouch:
+        case .trackTouch, .onLocationOnceMoved, .onLocation:
             viewModel = updateViewModel(viewModel, to: location)
         }
     }
@@ -132,8 +132,10 @@ open class Slider: UIView {
 private extension Slider {
     func handleTouchDown(on point: CGPoint) {
         switch options.trackingBehavior {
-        case .trackMovement:
+        case .trackMovement, .onTranslation, .onLocationOnceMoved:
             break
+        case .onLocation:
+            viewModel = updateViewModel(viewModel, to: point)
         case .trackTouch(let respondsImmediately):
             guard respondsImmediately else {
                 return

--- a/Sources/Slyderin/ThumblessSlider+Scaling.swift
+++ b/Sources/Slyderin/ThumblessSlider+Scaling.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  
+//
+//  Created by iMoe Nya on 2024/3/19.
+//
+
+import Foundation
+
+public extension ThumblessSlider {
+    public enum Scaling {
+        case onAxis(_ ratio: CGFloat)
+        case againstAxis(_ ratio: CGFloat)
+        case none
+        case both(onAxis: CGFloat, againstAxis: CGFloat)
+        
+        var scaleRatio: ScaleRatio {
+            switch self {
+            case .none:
+                return ScaleRatio(onAxis: 1, againstAxis: 1)
+            case .againstAxis(let ratio):
+                return ScaleRatio(onAxis: 1, againstAxis: ratio)
+            case .onAxis(let ratio):
+                return ScaleRatio(onAxis: ratio, againstAxis: 1)
+            case .both(let onAxis, let againstAxis):
+                return ScaleRatio(onAxis: onAxis, againstAxis: againstAxis)
+            }
+        }
+    }
+}

--- a/Sources/Slyderin/ThumblessSlider.swift
+++ b/Sources/Slyderin/ThumblessSlider.swift
@@ -14,16 +14,32 @@ open class ThumblessSlider: UIView, Slidable {
     }
     
     public struct ScaleRatio {
-        public var ratioOnAxis: CGFloat
-        public var ratioAgainstAxis: CGFloat
+        @available(*, deprecated, renamed: "onAxis", message: "")
+        public var ratioOnAxis: CGFloat {
+            onAxis
+        }
+        @available(*, deprecated, renamed: "againstAxis", message: "")
+        public var ratioAgainstAxis: CGFloat {
+            againstAxis
+        }
+        @available(*, deprecated, renamed: "init(onAxis:againstAxis:)", message: "")
         public init(ratioOnAxis: CGFloat, ratioAgainstAxis: CGFloat) {
-            self.ratioOnAxis = ratioOnAxis
-            self.ratioAgainstAxis = ratioAgainstAxis
+            self.onAxis = ratioOnAxis
+            self.againstAxis = ratioAgainstAxis
+        }
+        
+        public var onAxis: CGFloat
+        public var againstAxis: CGFloat
+        public init(onAxis: CGFloat, againstAxis: CGFloat) {
+            self.onAxis = onAxis
+            self.againstAxis = againstAxis
         }
     }
     
     public let direction: Direction
+    
     public let scaleRatio: ScaleRatio
+    
     public let cornerRadius: CornerRadius
     open var visualEffect: UIVisualEffect? {
         didSet {
@@ -32,7 +48,7 @@ open class ThumblessSlider: UIView, Slidable {
     }
     
     open class var defaultScaleRatio: ScaleRatio {
-        ScaleRatio(ratioOnAxis: 1, ratioAgainstAxis: 1)
+        ScaleRatio(onAxis: 1, againstAxis: 1)
     }
     
     open class var defaultDirection: Direction {
@@ -91,10 +107,24 @@ open class ThumblessSlider: UIView, Slidable {
     ) {
         self.direction = direction
         self.scaleRatio = scaleRatio
-        self.cornerRadius = cornerRadius
-        self.visualEffect = visualEffect
+        self.cornerRadius = Self.defaultCornerRadius
+        self.visualEffect = Self.defaultVisualEffect
         super.init(frame: .zero)
         buildView()
+    }
+    
+    public convenience init(
+        direction: Direction = defaultDirection,
+        scaling: Scaling,
+        cornerRadius: CornerRadius = defaultCornerRadius,
+        visualEffect: UIVisualEffect = defaultVisualEffect
+    ) {
+        self.init(
+            direction: direction,
+            scaleRatio: scaling.scaleRatio,
+            cornerRadius: cornerRadius,
+            visualEffect: visualEffect
+        )
     }
     
     public required init?(coder: NSCoder) {
@@ -168,7 +198,7 @@ open class ThumblessSlider: UIView, Slidable {
         }
     }
     
-    public func fit(_ viewModel: Slyder.ViewModel) {
+    public func fit(_ viewModel: Slider.ViewModel) {
         let valueRatio = viewModel.value / (viewModel.maximumValue + viewModel.minimumValue)
         if self.valueRatio != valueRatio {
             self.valueRatio = valueRatio

--- a/Sources/Slyderin/UIKitSlider.swift
+++ b/Sources/Slyderin/UIKitSlider.swift
@@ -12,7 +12,7 @@ open class UIKitSlider: UISlider, Slidable {
         .leadingToTrailing
     }
     
-    open func fit(_ viewModel: Slyder.ViewModel) {
+    open func fit(_ viewModel: Slider.ViewModel) {
         // no scale transform
         maximumValue = Float(viewModel.maximumValue)
         minimumValue = Float(viewModel.minimumValue)


### PR DESCRIPTION
Renaming: 
- `Slyder` to `Slider`, use `Slyderin.Slider` to avoid conflicts.
- `ScaleRatio.ratioOnAxis` to `ScaleRatio.onAxis`
- `ScaleRatio.ratioAgainstAxis` to `ScaleRatio.againstAxis`
- `Option.trackingBehavior` to `Option.tracks`
- `TrackingBehavior.trackTouch` to `TrackingBehavior.onLocation` / `TrackingBehavior.onLocationOnceMoved`
- `TrackingBehavior.trackMovement` to `TrackingBehavior.onTranslation`


Provided a more convenient way to specify how you want your thumbless slider to scale on initializing:
```swift
ThumblessSlider(scaling: .againstAxis(2))
```